### PR TITLE
Fix TE names in subfamily count table

### DIFF
--- a/squire/Call.py
+++ b/squire/Call.py
@@ -319,7 +319,10 @@ def main(**kwargs):
             countline = "\t".join(count_list)
             DEfile.writelines(gene + "\t" + countline + "\n")
         for TE_key,sample_dict in TE_dict.iteritems():
-            TE_out=",".join(TE_key)
+            if subfamily:
+                TE_out = TE_key
+            else:
+                TE_out=",".join(TE_key)
             count_list = []
             for sample in sample_list:
                 if sample in sample_dict:


### PR DESCRIPTION
If you use "--subfamily" to get subfamily TE counts in the Call step, the TE names in the subfamily count table will be joined by comma. For instance, "L3b:CR1:LINE" becomes "L,3,b,:,C,R,1,:,L,I,N,E" in the count table. This PR resolves the issue.